### PR TITLE
improve(runMulti): Improve threadCount steps to find max throughput

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/StressAction.java
+++ b/tools/stress/src/org/apache/cassandra/stress/StressAction.java
@@ -160,10 +160,12 @@ public class StressAction implements Runnable
 
             runIds.add(threadCount + " threadCount");
             prevThreadCount = threadCount;
-            if (threadCount < 16)
-                threadCount *= 2;
+            if (threadCount < 500)
+                threadCount += 100;
+            else if (threadCount < 1500)
+                threadCount *= 1.2;
             else
-                threadCount *= 1.5;
+                threadCount *= 1.1;
 
             if (!results.isEmpty() && threadCount > settings.rate.maxThreads)
                 break;


### PR DESCRIPTION
In order to have better granularity of threadCount and reach max throughput faster this commit suggests to grow quicker to around 500 threads where ScyllaDB usually starts to shine. Then, better granularity when getting closer to the max throughput, helps to find the optimal threadCount to reach maximum throughput.

This is a quick fix, until implementing a better feedback loop that increase/decrease threadCount based on percentage improvement of previous step.