### PR TITLE
feat(cassandra.in.sh): Refactor script for readability and consistency

### DIFF
--- a/tools/bin/cassandra.in.sh
+++ b/tools/bin/cassandra.in.sh
@@ -15,11 +15,11 @@
 # limitations under the License.
 
 if [ "$SCYLLA_HOME" = "" ]; then
-    SCYLLA_HOME="$(dirname "$0")/../../../scylla"
+  SCYLLA_HOME="$(dirname "$0")/../.."
 fi
 
 if [ "$SCYLLA_CONF" = "" ]; then
-    SCYLLA_CONF="$SCYLLA_HOME/conf"
+  SCYLLA_CONF="$SCYLLA_HOME/conf"
 fi
 
 # The java classpath (required)
@@ -28,13 +28,13 @@ CLASSPATH="$SCYLLA_CONF"
 # This can be the path to a jar file, or a directory containing the
 # compiled classes. NOTE: This isn't needed by the startup script,
 # it's just used here in constructing the classpath.
-if [ -d "$SCYLLA_HOME/build" ] ; then
-    cassandra_bin="$SCYLLA_HOME/build/classes/main"
-    cassandra_bin="$cassandra_bin:$SCYLLA_HOME/build/classes/thrift"
-    # shellcheck disable=SC2006
-    cassandra_bin="$cassandra_bin:`ls -1 $SCYLLA_HOME/build/apache-cassandra*.jar`"
-    cassandra_bin="$cassandra_bin:$SCYLLA_HOME/build/classes/stress"
-    CLASSPATH="$CLASSPATH:$cassandra_bin"
+if [ -d "$SCYLLA_HOME/build" ]; then
+  cassandra_bin="$SCYLLA_HOME/build/classes/main"
+  cassandra_bin="$cassandra_bin:$SCYLLA_HOME/build/classes/thrift"
+  # shellcheck disable=SC2006
+  cassandra_bin="$cassandra_bin:$(ls -1 $SCYLLA_HOME/build/apache-cassandra*.jar 2>/dev/null)"
+  cassandra_bin="$cassandra_bin:$SCYLLA_HOME/build/classes/stress"
+  CLASSPATH="$CLASSPATH:$cassandra_bin"
 fi
 
 # the default location for commitlogs, sstables, and saved caches
@@ -44,42 +44,41 @@ cassandra_storagedir="$SCYLLA_HOME/data"
 # JAVA_HOME can optionally be set here
 #JAVA_HOME=/usr/local/jdk6
 
-
 CONFIG_FILE_REALPATH=$(realpath "$SCYLLA_CONF/cassandra.yaml")
 # If scylla.yaml is found - use it as the config file.
 if [ -f "$SCYLLA_CONF/scylla.yaml" ]; then
-    CONFIG_FILE_REALPATH=$(realpath "$SCYLLA_CONF/scylla.yaml")
+  CONFIG_FILE_REALPATH=$(realpath "$SCYLLA_CONF/scylla.yaml")
 fi
 
 CONFIGURATION_FILE_OPT="-Dcassandra.config=file://$CONFIG_FILE_REALPATH"
 
 for jar in "$SCYLLA_HOME"/tools/lib/*.jar; do
-    CLASSPATH="$CLASSPATH:$jar"
+  CLASSPATH="$CLASSPATH:$jar"
 done
 
-for jar in "$SCYLLA_HOME"/lib/*.jar; do
-    CLASSPATH="$CLASSPATH:$jar"
+for jar in "$SCYLLA_HOME"/build/lib/jars/*.jar; do
+  CLASSPATH="$CLASSPATH:$jar"
 done
 
 # Use JAVA_HOME if set, otherwise look for java in PATH
 if [ -n "$JAVA_HOME" ]; then
-    # Why we can't have nice things: Solaris combines x86 and x86_64
-    # installations in the same tree, using an unconventional path for the
-    # 64bit JVM.  Since we prefer 64bit, search the alternate path first,
-    # (see https://issues.apache.org/jira/browse/SCYLLA-4638).
-    for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
-        if [ -x "$java" ]; then
-            JAVA="$java"
-            break
-        fi
-    done
+  # Why we can't have nice things: Solaris combines x86 and x86_64
+  # installations in the same tree, using an unconventional path for the
+  # 64bit JVM.  Since we prefer 64bit, search the alternate path first,
+  # (see https://issues.apache.org/jira/browse/SCYLLA-4638).
+  for java in "$JAVA_HOME"/bin/amd64/java "$JAVA_HOME"/bin/java; do
+    if [ -x "$java" ]; then
+      JAVA="$java"
+      break
+    fi
+  done
 else
-    JAVA=java
+  JAVA=java
 fi
 
-if [ -z $JAVA ] ; then
-    echo Unable to find java executable. Check JAVA_HOME and PATH environment variables. >&2
-    exit 1;
+if [ -z $JAVA ]; then
+  echo Unable to find java executable. Check JAVA_HOME and PATH environment variables. >&2
+  exit 1
 fi
 
 # Determine the sort of JVM we'll be running on.
@@ -87,34 +86,33 @@ java_ver_output=$("${JAVA:-java}" -version 2>&1)
 jvmver=$(echo "$java_ver_output" | grep '[openjdk|java] version' | awk -F'"' 'NR==1 {print $2}' | cut -d- -f1)
 JVM_VERSION=${jvmver%_*}
 
-if [ "$JVM_VERSION" \< "11" ] ; then
-    echo "Cassandra-Stress requires Java 11 (or newer)."
-    exit 1;
+if [ "$JVM_VERSION" \< "11" ]; then
+  echo "Cassandra-Stress requires Java 11 (or newer)."
+  exit 1
 fi
 
 jvm=$(echo "$java_ver_output" | grep -A 1 '[openjdk|java] version' | awk 'NR==2 {print $1}')
 case "$jvm" in
-    OpenJDK)
-        JVM_VENDOR=OpenJDK
-        # this will be "64-Bit" or "32-Bit"
-        JVM_ARCH=$(echo "$java_ver_output" | awk 'NR==3 {print $2}')
-        ;;
-    "Java(TM)")
-        JVM_VENDOR=Oracle
-        # this will be "64-Bit" or "32-Bit"
-        JVM_ARCH=$(echo "$java_ver_output" | awk 'NR==3 {print $3}')
-        ;;
-    *)
-        # Help fill in other JVM values
-        JVM_VENDOR=other
-        JVM_ARCH=unknown
-        ;;
+OpenJDK)
+  JVM_VENDOR=OpenJDK
+  # this will be "64-Bit" or "32-Bit"
+  JVM_ARCH=$(echo "$java_ver_output" | awk 'NR==3 {print $2}')
+  ;;
+"Java(TM)")
+  JVM_VENDOR=Oracle
+  # this will be "64-Bit" or "32-Bit"
+  JVM_ARCH=$(echo "$java_ver_output" | awk 'NR==3 {print $3}')
+  ;;
+*)
+  # Help fill in other JVM values
+  JVM_VENDOR=other
+  JVM_ARCH=unknown
+  ;;
 esac
 
 # Read user-defined JVM options from jvm-server.options file
 JVM_OPTS_FILE=$SCYLLA_CONF/jvm11${jvmoptions_variant:--clients}.options
 
-for opt in $(grep "^-" "$JVM_OPTS_FILE")
-do
+for opt in $(grep "^-" "$JVM_OPTS_FILE"); do
   JVM_OPTS="$JVM_OPTS $opt"
 done


### PR DESCRIPTION
This commit refactors the cassandra.in.sh script to improve readability
and consistency. Changes include adjusting indentation, modifying the
path for jar files, and streamlining the JVM version and vendor
detection. The changes aim to enhance maintainability and adherence to
coding standards.

But mainly including the path correction for looking the files up:

```diff
-  SCYLLA_HOME="$(dirname "$0")/../../../scylla"
+  SCYLLA_HOME="$(dirname "$0")/../.."
```

Signed-off-by: Daniel Boll <danielboll.academico@gmail.com>
