### PR TITLE
Print thread dump on specific signals

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/Stress.java
+++ b/tools/stress/src/org/apache/cassandra/stress/Stress.java
@@ -231,5 +231,7 @@ public final class Stress
         Signal.handle(new Signal("ABRT"), handler);
         Signal.handle(new Signal("TERM"), handler);
         Signal.handle(new Signal("INT"), handler);
+        Signal.handle(new Signal("TERM"), handler);
+        Signal.handle(new Signal("INT"), handler);
     }
 }

--- a/tools/stress/src/org/apache/cassandra/stress/Stress.java
+++ b/tools/stress/src/org/apache/cassandra/stress/Stress.java
@@ -231,7 +231,5 @@ public final class Stress
         Signal.handle(new Signal("ABRT"), handler);
         Signal.handle(new Signal("TERM"), handler);
         Signal.handle(new Signal("INT"), handler);
-        Signal.handle(new Signal("TERM"), handler);
-        Signal.handle(new Signal("INT"), handler);
     }
 }


### PR DESCRIPTION
Adds a signal handler that will print thread dump to standard output on
the following signals: SIGABRT, SIGTERM, SIGINT.
Does not work for SIGKILL or other abrupt shutdowns.

Addresses scylladb/scylla-tools-java/issues/407