### PR TITLE
Switch to `ReplicaOrdering.RANDOM` for select LBPs

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -103,6 +103,7 @@ public class JavaDriverClient
     private LoadBalancingPolicy loadBalancingPolicy(StressSettings settings)
     {
         LoadBalancingPolicy ret = null;
+        ReplicaOrdering replicaOrdering = null;
 
         if (settings.node.rack != null) {
             RackAwareRoundRobinPolicy.Builder policyBuilder = RackAwareRoundRobinPolicy.builder();
@@ -110,15 +111,17 @@ public class JavaDriverClient
                 policyBuilder.withLocalDc(settings.node.datacenter);
             policyBuilder = policyBuilder.withLocalRack(settings.node.rack);
             ret = policyBuilder.build();
+            replicaOrdering = ReplicaOrdering.NEUTRAL;
         } else {
             DCAwareRoundRobinPolicy.Builder policyBuilder = DCAwareRoundRobinPolicy.builder();
             if (settings.node.datacenter != null)
                 policyBuilder.withLocalDc(settings.node.datacenter);
             ret = policyBuilder.build();
+            replicaOrdering = ReplicaOrdering.RANDOM;
         }
         if (settings.node.isWhiteList)
             ret = new WhiteListPolicy(ret, settings.node.resolveAll(settings.port.nativePort));
-        return new TokenAwarePolicy(ret, ReplicaOrdering.NEUTRAL);
+        return new TokenAwarePolicy(ret, replicaOrdering);
     }
 
     public PreparedStatement prepare(String query)


### PR DESCRIPTION
This setting has the benefit of evenly distributing the load across replicas. Using round robin policies with `NEUTRAL` ordering can easily lead to spikes in load on singular nodes during cluster grow and uneven workload afterwards when using tablets.

The reason for not switching to `RANDOM` for rack aware LBP right now is that it is slightly broken in that configuration.
See java-driver/369.