### PR TITLE
fix `counter_write` table creation

### DIFF
--- a/src/java/org/apache/cassandra/stress/settings/SettingsSchema.java
+++ b/src/java/org/apache/cassandra/stress/settings/SettingsSchema.java
@@ -46,6 +46,8 @@ public class SettingsSchema implements Serializable
     private final String compactionStrategy;
     private final Map<String, String> compactionStrategyOptions;
     public final String keyspace;
+    private final Command cmd_type;
+
 
     public SettingsSchema(Options options, SettingsCommand command)
     {
@@ -61,6 +63,7 @@ public class SettingsSchema implements Serializable
         compression = options.compression.value();
         compactionStrategy = options.compaction.getStrategy();
         compactionStrategyOptions = options.compaction.getOptions();
+        cmd_type = command.type;
     }
 
     public void createKeySpaces(StressSettings settings)
@@ -92,6 +95,13 @@ public class SettingsSchema implements Serializable
 
             //Add standard1
             client.execute(createStandard1StatementCQL3(settings), org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM);
+
+
+            if (cmd_type == Command.COUNTER_WRITE)
+            {
+                //Add counter1
+                client.execute(createCounter1StatementCQL3(settings), org.apache.cassandra.db.ConsistencyLevel.LOCAL_QUORUM);
+            }
 
             System.out.println(String.format("Created keyspaces. Sleeping %ss for propagation.", settings.node.nodes.size()));
             Thread.sleep(settings.node.nodes.size() * 1000L); // seconds


### PR DESCRIPTION
seems like at some point counter table creation was dropped from this fork, SCT was creating the those tables on it's own when needed

this commit introduce it back, but base on the type of the command so it won't intefere with command that doesn't need it (tablets for example doesn't support counter tables yet)

Fixes: #63