### PR TITLE
Relax requirements on installed Java

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1015,8 +1015,8 @@
             encoding="utf-8"
             destdir="${build.classes.main}"
             includeantruntime="false"
-            source="${ant.java.version}"
-            target="${ant.java.version}"
+            source="${source.version}"
+            target="${target.version}"
             memorymaximumsize="512M">
             <src path="${build.src.java}" />
             <src path="${build.src.gen-java}" />

--- a/dist/debian/control
+++ b/dist/debian/control
@@ -11,4 +11,4 @@ Priority: extra
 Architecture: all
 Recommends: ntp | time-daemon
 Description: Cassandra-stress is a Java-based command-line stress testing tool for Apache Cassandra and Scylla.
-Depends: openjdk-11-jre-headless | openjdk-11-jre | oracle-java11-set-default | temurin-11-jre, procps, libsnappy-java, libsnappy-jni
+Depends: java-runtime-headless, procps, libsnappy-java, libsnappy-jni

--- a/dist/redhat/cassandra-stress.spec
+++ b/dist/redhat/cassandra-stress.spec
@@ -8,7 +8,7 @@ License:        Apache
 URL:            http://www.scylladb.com/
 Source0:        cassandra-stress.tar.gz
 BuildArch:      noarch
-Requires:       (jre-11-headless or temurin-11-jre) snappy
+Requires:       java-headless snappy
 AutoReqProv:    no
 
 %description


### PR DESCRIPTION
Require generic headless Java rather than some specific Java 11 variant. Change the build process to build for Java 11, so it can be built on any Java as well.