### PR TITLE
fix(docker): handle entrypoint better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,4 @@ RUN --mount=type=cache,target=/var/cache/apt ln -snf "/usr/share/zoneinfo/$TZ" /
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-ENTRYPOINT [ "/bin/bash", "-o", "pipefail", "-c" ]
-
-CMD ["cassandra-stress"]
+ENTRYPOINT ["cassandra-stress"]


### PR DESCRIPTION
the current entrypoint wasn't that user-friendly
and doesn't follow the expactaions of the common user it was following the login needed for SCT usage
(Dockerfile came from that repo)

now `cassandra-stress` is the entrypoint, and those command works:
```bash
$ docker run --rm  docker.io/scylladb/cassandra-stress:latest write
$ podman run --rm  docker.io/scylladb/cassandra-stress:latest write
```

Fix: scylladb/cassandra-stress#76