### PR TITLE
fix(java-modules): --add-opens for newer java version

### DIFF
--- a/conf/jvm-clients.options
+++ b/conf/jvm-clients.options
@@ -11,6 +11,11 @@
 -Djdk.attach.allowAttachSelf=true
 --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
 --add-opens java.base/jdk.internal.module=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED
+--add-opens java.base/java.net=ALL-UNNAMED
+--add-opens java.base/sun.nio.ch=ALL-UNNAMED
 --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
 --add-exports java.base/sun.nio.ch=ALL-UNNAMED
 --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED


### PR DESCRIPTION
In newer Java versions (Java 9+), `--add-opens` flag has been added, to improve security and unwanted modules from being loaded. This requirement has been stricter in Java 15+ and requires us to add even the basic modules to `--add-opens`

Closes #77