### PR TITLE
Switch to RANDOM replica ordering for RACK-aware lb policy

### DIFF
--- a/src/java/org/apache/cassandra/stress/util/JavaDriverClient.java
+++ b/src/java/org/apache/cassandra/stress/util/JavaDriverClient.java
@@ -102,26 +102,22 @@ public class JavaDriverClient
 
     private LoadBalancingPolicy loadBalancingPolicy(StressSettings settings)
     {
-        LoadBalancingPolicy ret = null;
-        ReplicaOrdering replicaOrdering = null;
-
+        LoadBalancingPolicy ret;
         if (settings.node.rack != null) {
             RackAwareRoundRobinPolicy.Builder policyBuilder = RackAwareRoundRobinPolicy.builder();
             if (settings.node.datacenter != null)
                 policyBuilder.withLocalDc(settings.node.datacenter);
             policyBuilder = policyBuilder.withLocalRack(settings.node.rack);
             ret = policyBuilder.build();
-            replicaOrdering = ReplicaOrdering.NEUTRAL;
         } else {
             DCAwareRoundRobinPolicy.Builder policyBuilder = DCAwareRoundRobinPolicy.builder();
             if (settings.node.datacenter != null)
                 policyBuilder.withLocalDc(settings.node.datacenter);
             ret = policyBuilder.build();
-            replicaOrdering = ReplicaOrdering.RANDOM;
         }
         if (settings.node.isWhiteList)
             ret = new WhiteListPolicy(ret, settings.node.resolveAll(settings.port.nativePort));
-        return new TokenAwarePolicy(ret, replicaOrdering);
+        return new TokenAwarePolicy(ret, ReplicaOrdering.RANDOM);
     }
 
     public PreparedStatement prepare(String query)


### PR DESCRIPTION
After driver issue https://github.com/scylladb/java-driver/issues/369 is fixed we can switch to **RANDOM** replica ordering for **RACK-aware** load balancing policy.