### PR TITLE
Revert ".github/workflows: Migrate workflows to Blacksmith runners"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,15 +53,15 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       BUILDX_GIT_INFO: 1
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -69,13 +69,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password:  ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push API
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           file: Dockerfile
           context: .
           push: true
           pull: true
           platforms: ${{ inputs.platforms }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ inputs.image }}:latest
             ${{ inputs.image }}:${{ inputs.version }}

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/dockerhub-description.yml
 jobs:
   description:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tag:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version_tag.outputs.tag }}
     steps:
@@ -43,7 +43,7 @@ jobs:
       java: '${{ matrix.java }}'
   release:
     needs: ['tag', 'docker', 'build']
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v6
         with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   test:
     name: "Test ${{ inputs.os }} with Java ${{ inputs.java }}"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["21"]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
         with:
@@ -75,7 +75,7 @@ jobs:
   enumerated-tests:
     timeout-minutes: 2
     name: "Enumerate all tests from integration-tests folder to run them independently"
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.enumerate.outputs.matrix }}
     steps:
@@ -108,7 +108,7 @@ jobs:
       matrix:
         java: ["21"]
         test: ${{ fromJSON(needs.enumerated-tests.outputs.matrix) }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v5


### PR DESCRIPTION
seems like it's not needed by OSS repos

Reverts scylladb/cassandra-stress#111