### PR TITLE
.github/workflows/test-package.yml: Potential fix for code scanning alert no. 75: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,4 +1,6 @@
 name: "Test Distribution"
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/cassandra-stress/security/code-scanning/75](https://github.com/scylladb/cassandra-stress/security/code-scanning/75)

In general, the fix is to explicitly declare a `permissions:` block that grants the minimal GITHUB_TOKEN scopes required by the workflow, either at the workflow root (applies to all jobs) or per job. This workflow only checks out code and downloads an artifact, then runs local scripts; it does not interact with issues, PRs, or push to the repo. Therefore, it can safely restrict permissions to read-only access to repository contents.

The single best fix here, without changing existing functionality, is to add a top-level `permissions:` block right after the `name:` (before `on:`) in `.github/workflows/test-package.yml`, setting `contents: read`. This will apply to the `test` job and any future jobs that don’t override permissions, and it will ensure the GITHUB_TOKEN cannot perform write operations on the repository. No imports or additional methods are needed since this is a YAML configuration change only.

Concretely, in `.github/workflows/test-package.yml`, add:

```yaml
permissions:
  contents: read
```

after line 1 (`name: "Test Distribution"`), keeping the existing indentation and structure intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
