### PR TITLE
fix(ssl): replace legacy RSA/CBC cipher defaults with TLS 1.3 and ECDHE equivalents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.9_10-jdk-noble AS build
+FROM eclipse-temurin:21.0.10_7-jdk-noble AS build
 
 ENV LD_LIBRARY_PATH="/lib/x86_64-linux-gnu:/usr/local/lib:/usr/lib:/lib:/lib64:/usr/local/lib/x86_64-linux-gnu"
 ENV DEBIAN_FRONTEND="noninteractive"
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.m2 ant realclean \
     && chmod +x build/dist/bin/cassandra-stress
 
 
-FROM eclipse-temurin:21.0.9_10-jre-noble AS production
+FROM eclipse-temurin:21.0.10_7-jre-noble AS production
 
 LABEL org.opencontainers.image.source="https://github.com/scylladb/cassandra-stress"
 LABEL org.opencontainers.image.title="ScyllaDB Cassandra Stress"

--- a/src/java/org/apache/cassandra/stress/settings/SettingsTransport.java
+++ b/src/java/org/apache/cassandra/stress/settings/SettingsTransport.java
@@ -138,7 +138,7 @@ public class SettingsTransport implements Serializable
         final OptionSimple protocol = new OptionSimple("ssl-protocol=", ".*", "TLS", "SSL: connection protocol to use", false);
         final OptionSimple alg = new OptionSimple("ssl-alg=", ".*", "SunX509", "SSL: algorithm", false);
         final OptionSimple storeType = new OptionSimple("store-type=", ".*", "JKS", "SSL: keystore format", false);
-        final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*", "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA", "SSL: comma delimited list of encryption suites to use", false);
+        final OptionSimple ciphers = new OptionSimple("ssl-ciphers=", ".*", "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "SSL: comma delimited list of encryption suites to use", false);
         final OptionSimple hostnameVerification = new OptionSimple("hostname-verification=", ".*", "false", "SSL: enable hostname verification in Java Driver", false);
 
         @Override


### PR DESCRIPTION
## Problem

JDK 21.0.10 disabled `TLS_RSA_WITH_AES_128_CBC_SHA` and `TLS_RSA_WITH_AES_256_CBC_SHA` via `jdk.tls.disabledAlgorithms` in `java.security`. These were the hardcoded default cipher suites in `SettingsTransport.java`, so every SSL-enabled cassandra-stress run silently failed with a TLS handshake error after the eclipse-temurin image was bumped from `21.0.9_10` → `21.0.10_7` in v3.20.2.

The symptom surfaced in SCT when using the `certstore` transport flag with encryption enabled (scylladb/scylla-cluster-tests#13708). The workaround there was to pass explicit TLS 1.3 ciphers via `ssl-ciphers=`. v3.20.5 reverted the JDK bump as a stopgap, but left the broken cipher defaults in place.

Root cause: the two RSA key-exchange ciphers have no forward secrecy and have been on OpenJDK's deprecation path for years — 21.0.10 finally disabled them.

## Fix

Replace the defaults in `SettingsTransport.java` with:

| Cipher | Protocol | Notes |
|--------|----------|-------|
| `TLS_AES_256_GCM_SHA384` | TLS 1.3 | preferred |
| `TLS_AES_128_GCM_SHA256` | TLS 1.3 | preferred |
| `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384` | TLS 1.2 | backward compat |
| `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` | TLS 1.2 | backward compat |

TLS 1.3 ciphers are negotiated when both sides support them. Older Scylla/Cassandra nodes that only speak TLS 1.2 fall back to the ECDHE/GCM ciphers, which are secure and fully supported by JDK 21.0.10+.

Re-enables the eclipse-temurin upgrade to `21.0.10_7` in the Dockerfile now that the root cause is addressed.

## Test plan

- [ ] Run cassandra-stress with `transport{certstore=... ssl-enabled=true}` against a TLS-enabled ScyllaDB node — confirm handshake succeeds without passing explicit `ssl-ciphers`
- [ ] Confirm the SCT test suite (scylladb/scylla-cluster-tests#13708) passes without the workaround cipher override
- [ ] Verify backward compat against an older node that only supports TLS 1.2