### PR TITLE
release: trigger Jenkins sign-cassandra-stress pipeline after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,17 @@ jobs:
           branch: ${{ github.event.repository.default_branch }}
           commit_options: '--no-verify --signoff'
           file_pattern: CHANGELOG.md
+
+  sign-packages:
+    needs: ['tag', 'release']
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger Jenkins sign-cassandra-stress pipeline
+        run: |
+          curl -sf -X POST \
+            "https://jenkins.scylladb.com/job/releng/job/sign-cassandra-stress/buildWithParameters" \
+            --user "${{ secrets.JENKINS_USERNAME }}:${{ secrets.JENKINS_TOKEN }}" \
+            --data-urlencode "CASSANDRA_STRESS_VERSION=${{ needs.tag.outputs.version }}" \
+            --data-urlencode "GITHUB_RELEASE_TAG=v${{ needs.tag.outputs.version }}" \
+            --data-urlencode "UPLOAD_TO_RELEASE=true" \
+            --data-urlencode "UPLOAD_TO_S3=true"


### PR DESCRIPTION
After a release is published, trigger the Jenkins `sign-cassandra-stress` pipeline to sign the RPM and DEB packages and upload them back to the GitHub release.

Depends on https://github.com/scylladb/scylla-pkg/pull/6314