### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,15 +33,15 @@ jobs:
         os: ["ubuntu-24.04"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "temurin"
           java-version: ${{ inputs.java }}
       - name: Setup Ant
-        uses: cedx/setup-ant@v6
+        uses: cedx/setup-ant@da941eb444b657ea183d731ba96e59ec26411014 # v6.3.0
         with:
           optional-tasks: true
           version: latest
@@ -72,7 +72,7 @@ jobs:
           mv build/cassandra-stress-src.tar.gz.sha512 build/cassandra-stress-src-java${{ inputs.java }}.tar.gz.sha512
           mv build/cassandra-stress_${{ inputs.version }}_all.deb build/cassandra-stress-java${{ inputs.java }}_${{ inputs.version }}_all.deb
           mv build/cassandra-stress-${{ inputs.version }}-1.noarch.rpm build/cassandra-stress-java${{ inputs.java }}-${{ inputs.version }}-1.noarch.rpm
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cassandra-stress-java${{ inputs.java }}
           path: |

--- a/.github/workflows/close_issue_for_scylla_employee.yml
+++ b/.github/workflows/close_issue_for_scylla_employee.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Comment and close if author email is scylladb.com
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,21 +57,21 @@ jobs:
       BUILDX_GIT_INFO: 1
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ secrets.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password:  ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push API
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           file: Dockerfile
           context: .

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -10,10 +10,10 @@ jobs:
   description:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Docker Hub Description
-      uses: peter-evans/dockerhub-description@v5
+      uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password:  ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     outputs:
       version: ${{ steps.version_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
       - name: Get Tag
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: olegtarasov/get-tag@v2.1.4
+        uses: olegtarasov/get-tag@9a8716825750e73195b02db42777b92ffe960605 # v2.1.4
         id: version_tag
         with:
           tagRegex: "v(.*)"
@@ -45,14 +45,14 @@ jobs:
     needs: ['tag', 'docker', 'build']
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cassandra-stress-java21
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         id: release
         with:
           make_latest: true
@@ -73,14 +73,14 @@ jobs:
             cassandra-stress-java21-${{ needs.tag.outputs.version }}-1.noarch.rpm
       - name: "Build Changelog"
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v6
+        uses: mikepenz/release-changelog-builder-action@c9bcd8238b6f41e05561348339429d360b1c0247 # v6.2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configuration: ".github/changelog-config.json"
           outputFile: CHANGELOG.md
           ignorePreReleases: false
       - name: "Commit Changelog"
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: "docs: update CHANGELOG.md for v${{ needs.tag.outputs.version }}"
           branch: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -27,10 +27,10 @@ jobs:
     name: "Test ${{ inputs.os }} with Java ${{ inputs.java }}"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cassandra-stress-java${{ inputs.java }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,15 +55,15 @@ jobs:
         java: ["21"]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java }}
       - name: Setup Ant
-        uses: cedx/setup-ant@v6
+        uses: cedx/setup-ant@da941eb444b657ea183d731ba96e59ec26411014 # v6.3.0
         with:
           optional-tasks: true
           version: latest
@@ -80,7 +80,7 @@ jobs:
       matrix: ${{ steps.enumerate.outputs.matrix }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Enumerate tests
@@ -112,15 +112,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Download Cassandra Stress binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cassandra-stress-java${{ matrix.java }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions to full commit SHAs to reduce supply chain attack surface
- Upgrade outdated actions to their latest versions

**This PR was generated automatically. Please verify that GitHub Actions work as expected with these changes before merging.**

Reference: https://github.com/scylladb/scylladb/pull/29421