### PR TITLE
fix: enrich read-validation error messages with diagnostic detail

### DIFF
--- a/src/java/org/apache/cassandra/stress/Operation.java
+++ b/src/java/org/apache/cassandra/stress/Operation.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.stress;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
 
 import com.datastax.driver.core.exceptions.OverloadedException;
@@ -48,9 +49,24 @@ public abstract class Operation
         public boolean run() throws Exception;
         public int partitionCount();
         public int rowCount();
+        default String validationErrorMessage() { return null; }
     }
 
     public abstract int ready(WorkManager permits);
+
+    // shared hex-dump preview used by validation diagnostics: caps at maxBytes and appends "..." if truncated
+    protected static String hexPreview(ByteBuffer bb, int maxBytes)
+    {
+        if (bb == null) return "null";
+        ByteBuffer dup = bb.duplicate();
+        int len = Math.min(dup.remaining(), maxBytes);
+        StringBuilder sb = new StringBuilder("0x");
+        for (int i = 0; i < len; i++)
+            sb.append(String.format("%02x", dup.get() & 0xFF));
+        if (dup.hasRemaining())
+            sb.append("...");
+        return sb.toString();
+    }
 
     public boolean isWrite()
     {
@@ -137,12 +153,15 @@ public abstract class Operation
 
         if (!success)
         {
-            error(String.format("Operation x%d on key(s) %s: %s%n",
-                    tries,
-                    key(),
-                    (exceptionMessage == null)
-                        ? "Data returned was not validated"
-                        : "Error executing: " + exceptionMessage));
+            String detail;
+            if (exceptionMessage != null)
+                detail = "Error executing: " + exceptionMessage;
+            else
+            {
+                String validationMsg = run.validationErrorMessage();
+                detail = (validationMsg != null) ? validationMsg : "Data returned was not validated";
+            }
+            error(String.format("Operation x%d on key(s) %s: %s%n", tries, key(), detail));
         }
 
     }

--- a/src/java/org/apache/cassandra/stress/generate/PartitionIterator.java
+++ b/src/java/org/apache/cassandra/stress/generate/PartitionIterator.java
@@ -766,9 +766,40 @@ public abstract class PartitionIterator implements Iterator<Row>
             if (i > 0)
                 sb.append("|");
             AbstractType type = generator.partitionKey.get(i++).type;
-            sb.append(type.getString(type.decompose(key)));
+            String typeStr = type.getString(type.decompose(key));
+            if (type instanceof BytesType)
+            {
+                String decoded = tryDecodeHexAsAscii(typeStr);
+                if (decoded != null)
+                    sb.append(decoded).append(" (hex: ").append(typeStr).append(")");
+                else
+                    sb.append(typeStr);
+            }
+            else
+            {
+                sb.append(typeStr);
+            }
         }
         return sb.toString();
+    }
+
+    private static String tryDecodeHexAsAscii(String hex)
+    {
+        if (hex == null || hex.length() == 0 || hex.length() % 2 != 0)
+            return null;
+        byte[] bytes = new byte[hex.length() / 2];
+        for (int i = 0; i < bytes.length; i++)
+        {
+            int hi = Character.digit(hex.charAt(i * 2), 16);
+            int lo = Character.digit(hex.charAt(i * 2 + 1), 16);
+            if (hi < 0 || lo < 0)
+                return null;
+            bytes[i] = (byte) ((hi << 4) | lo);
+            // only keep it if every byte is printable ASCII
+            if (bytes[i] < 0x20 || bytes[i] > 0x7E)
+                return null;
+        }
+        return new String(bytes, java.nio.charset.StandardCharsets.US_ASCII);
     }
 
     // used for thrift smart routing - if it's a multi-part key we don't try to route correctly right now

--- a/src/java/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
+++ b/src/java/org/apache/cassandra/stress/operations/predefined/CqlOperation.java
@@ -175,6 +175,7 @@ public abstract class CqlOperation<V> extends PredefinedOperation
     {
 
         final List<List<ByteBuffer>> expect;
+        private String validationError;
 
         // a null value for an item in expect means we just check the row is present
         protected CqlRunOpMatchResults(ClientWrapper client, String query, Object queryId, List<Object> params, ByteBuffer key, List<List<ByteBuffer>> expect)
@@ -195,17 +196,121 @@ public abstract class CqlOperation<V> extends PredefinedOperation
             return result == null ? 0 : result.length;
         }
 
+        @Override
+        public String validationErrorMessage()
+        {
+            return validationError;
+        }
+
+        // keep every validationError message single-line: SCT captures the whole matched log line as one event,
+        // so an embedded %n would silently split off part of the diagnostic detail.
         public boolean validate(ByteBuffer[][] result)
         {
             if (!settings.errors.skipReadValidation)
             {
-                if (result.length != expect.size())
+                int expectedRows = expect.size();
+                int actualRows = result.length;
+
+                if (actualRows != expectedRows)
+                {
+                    long expectedBytes = 0;
+                    int expectedColsPerRow = 0;
+                    if (expectedRows > 0 && expect.get(0) != null)
+                    {
+                        expectedColsPerRow = expect.get(0).size();
+                        for (List<ByteBuffer> row : expect)
+                            if (row != null) expectedBytes += totalBytes(row);
+                    }
+
+                    if (actualRows == 0)
+                    {
+                        validationError = String.format(
+                            "Data returned was not validated: row empty/missing" +
+                            " (expected %d row(s) with %d column(s) %s, %d bytes total (%dx%d); got 0 rows)",
+                            expectedRows, expectedColsPerRow,
+                            columnNamesPreview(expectedColsPerRow),
+                            expectedBytes, expectedColsPerRow,
+                            expectedColsPerRow > 0 ? expectedBytes / expectedColsPerRow : 0);
+                    }
+                    else
+                    {
+                        long actualBytes = 0;
+                        for (ByteBuffer[] row : result)
+                            if (row != null) actualBytes += totalBytes(row);
+                        validationError = String.format(
+                            "Data returned was not validated: row count mismatch" +
+                            " (expected %d row(s) / %d bytes total; got %d row(s) / %d bytes total)",
+                            expectedRows, expectedBytes, actualRows, actualBytes);
+                    }
                     return false;
+                }
+
                 for (int i = 0; i < result.length; i++)
-                    if (expect.get(i) != null && !expect.get(i).equals(Arrays.asList(result[i])))
+                {
+                    List<ByteBuffer> expectedRow = expect.get(i);
+                    if (expectedRow == null)
+                        continue;
+                    ByteBuffer[] actualRow = result[i];
+
+                    if (actualRow.length != expectedRow.size())
+                    {
+                        long expectedRowBytes = totalBytes(expectedRow);
+                        long actualRowBytes = totalBytes(actualRow);
+                        validationError = String.format(
+                            "Data returned was not validated: row %d column count mismatch" +
+                            " (expected %d column(s) %s / %d bytes; got %d column(s) / %d bytes)",
+                            i, expectedRow.size(), columnNamesPreview(expectedRow.size()),
+                            expectedRowBytes, actualRow.length, actualRowBytes);
                         return false;
+                    }
+
+                    for (int j = 0; j < expectedRow.size(); j++)
+                    {
+                        ByteBuffer expectedVal = expectedRow.get(j);
+                        ByteBuffer actualVal = actualRow[j];
+                        if (expectedVal != null && !expectedVal.equals(actualVal))
+                        {
+                            int expectedSize = expectedVal.remaining();
+                            int actualSize = (actualVal != null) ? actualVal.remaining() : -1;
+                            String colLabel = columnLabel(j);
+                            String diff;
+                            if (actualSize < 0)
+                                diff = String.format("got null (expected %d bytes)", expectedSize);
+                            else if (actualSize != expectedSize)
+                                diff = String.format("expected %d bytes, got %d bytes", expectedSize, actualSize);
+                            else
+                                diff = String.format("same size (%d bytes) but content differs; expected[0..%d]=%s, got[0..%d]=%s",
+                                    expectedSize,
+                                    Math.min(15, expectedSize - 1), hexPreview(expectedVal, 16),
+                                    Math.min(15, actualSize - 1),   hexPreview(actualVal, 16));
+                            validationError = String.format(
+                                "Data returned was not validated: row %d, %s: %s",
+                                i, colLabel, diff);
+                            return false;
+                        }
+                    }
+                }
             }
             return true;
+        }
+
+        private String columnLabel(int j)
+        {
+            List<String> names = settings.columns.namestrs;
+            if (names != null && j < names.size())
+                return String.format("column %d (%s)", j, names.get(j));
+            return String.format("column %d", j);
+        }
+
+        private String columnNamesPreview(int count)
+        {
+            List<String> names = settings.columns.namestrs;
+            if (names == null || names.isEmpty() || count <= 0)
+                return "";
+            int available = Math.min(count, names.size());
+            if (available <= 4)
+                return names.subList(0, available).toString();
+            return "[" + names.get(0) + ".." + names.get(available - 1) + "]";
         }
     }
 
@@ -756,6 +861,22 @@ public abstract class CqlOperation<V> extends PredefinedOperation
     protected String wrapInQuotes(String string)
     {
         return "\"" + string + "\"";
+    }
+
+    private static long totalBytes(List<ByteBuffer> bufs)
+    {
+        long total = 0;
+        for (ByteBuffer bb : bufs)
+            if (bb != null) total += bb.remaining();
+        return total;
+    }
+
+    private static long totalBytes(ByteBuffer[] bufs)
+    {
+        long total = 0;
+        for (ByteBuffer bb : bufs)
+            if (bb != null) total += bb.remaining();
+        return total;
     }
 
 }

--- a/src/java/org/apache/cassandra/stress/operations/userdefined/ValidatingSchemaQuery.java
+++ b/src/java/org/apache/cassandra/stress/operations/userdefined/ValidatingSchemaQuery.java
@@ -89,6 +89,7 @@ public class ValidatingSchemaQuery extends PartitionOperation
     {
         int partitionCount;
         int rowCount;
+        String validationError;
         final PartitionIterator iter;
         final int statementIndex;
 
@@ -108,6 +109,12 @@ public class ValidatingSchemaQuery extends PartitionOperation
         public int rowCount()
         {
             return rowCount;
+        }
+
+        @Override
+        public String validationErrorMessage()
+        {
+            return validationError;
         }
     }
 
@@ -142,7 +149,12 @@ public class ValidatingSchemaQuery extends PartitionOperation
                     break;
 
                 if (!results.hasNext())
+                {
+                    validationError = String.format(
+                        "Data returned was not validated: expected row %d but result set exhausted (row empty/missing)",
+                        rowCount + 1);
                     return false;
+                }
 
                 rowCount++;
                 com.datastax.driver.core.Row actualRow = results.next();
@@ -151,11 +163,29 @@ public class ValidatingSchemaQuery extends PartitionOperation
                     Object expectedValue = expectedRow.get(valueIndex[i]);
                     Object actualValue = spec.partitionGenerator.convert(valueIndex[i], actualRow.getBytesUnsafe(i));
                     if (!expectedValue.equals(actualValue))
+                    {
+                        String colName = actualRow.getColumnDefinitions().getName(i);
+                        validationError = String.format(
+                            "Data returned was not validated: row %d, column %d (%s): value mismatch" +
+                            " (expected [%s] %s, got [%s] %s)",
+                            rowCount, i, colName,
+                            expectedValue.getClass().getSimpleName(), describeValue(expectedValue),
+                            actualValue == null ? "null" : actualValue.getClass().getSimpleName(),
+                            actualValue == null ? "null" : describeValue(actualValue));
                         return false;
+                    }
                 }
             }
             partitionCount = Math.min(1, rowCount);
-            return rs.isExhausted();
+            if (!rs.isExhausted())
+            {
+                validationError = String.format(
+                    "Data returned was not validated: result set not exhausted after consuming %d expected row(s)" +
+                    " (got more rows than expected)",
+                    rowCount);
+                return false;
+            }
+            return true;
         }
     }
 
@@ -190,7 +220,12 @@ public class ValidatingSchemaQuery extends PartitionOperation
                     break;
 
                 if (!results.hasNext())
+                {
+                    validationError = String.format(
+                        "Data returned was not validated: expected row %d but result set exhausted (row empty/missing)",
+                        rowCount + 1);
                     return false;
+                }
 
                 rowCount++;
                 shaded.com.datastax.oss.driver.api.core.cql.Row actualRow = results.next();
@@ -199,11 +234,29 @@ public class ValidatingSchemaQuery extends PartitionOperation
                     Object expectedValue = expectedRow.get(valueIndex[i]);
                     Object actualValue = spec.partitionGenerator.convert(valueIndex[i], actualRow.getBytesUnsafe(i));
                     if (!expectedValue.equals(actualValue))
+                    {
+                        String colName = actualRow.getColumnDefinitions().get(i).getName().toString();
+                        validationError = String.format(
+                            "Data returned was not validated: row %d, column %d (%s): value mismatch" +
+                            " (expected [%s] %s, got [%s] %s)",
+                            rowCount, i, colName,
+                            expectedValue.getClass().getSimpleName(), describeValue(expectedValue),
+                            actualValue == null ? "null" : actualValue.getClass().getSimpleName(),
+                            actualValue == null ? "null" : describeValue(actualValue));
                         return false;
+                    }
                 }
             }
             partitionCount = Math.min(1, rowCount);
-            return rs.isFullyFetched();
+            if (!rs.isFullyFetched())
+            {
+                validationError = String.format(
+                    "Data returned was not validated: result set not exhausted after consuming %d expected row(s)" +
+                    " (got more rows than expected)",
+                    rowCount);
+                return false;
+            }
+            return true;
         }
     }
 
@@ -233,7 +286,12 @@ public class ValidatingSchemaQuery extends PartitionOperation
                     break;
 
                 if (r == rs.num)
+                {
+                    validationError = String.format(
+                        "Data returned was not validated: expected row %d but result set exhausted (row empty/missing)",
+                        rowCount + 1);
                     return false;
+                }
 
                 rowCount++;
                 CqlRow actualRow = rs.getRows().get(r++);
@@ -242,7 +300,21 @@ public class ValidatingSchemaQuery extends PartitionOperation
                     ByteBuffer expectedValue = spec.partitionGenerator.convert(valueIndex[i], expectedRow.get(valueIndex[i]));
                     ByteBuffer actualValue = actualRow.getColumns().get(i).value;
                     if (!expectedValue.equals(actualValue))
+                    {
+                        int expectedSize = (expectedValue != null) ? expectedValue.remaining() : -1;
+                        int actualSize = (actualValue != null) ? actualValue.remaining() : -1;
+                        String diff;
+                        if (actualSize < 0)
+                            diff = String.format("got null (expected %d bytes)", expectedSize);
+                        else if (actualSize != expectedSize)
+                            diff = String.format("expected %d bytes, got %d bytes", expectedSize, actualSize);
+                        else
+                            diff = String.format("same size (%d bytes) but content differs", expectedSize);
+                        validationError = String.format(
+                            "Data returned was not validated: row %d, column %d: %s",
+                            rowCount, i, diff);
                         return false;
+                    }
                 }
             }
             assert r == rs.num;
@@ -410,5 +482,22 @@ public class ValidatingSchemaQuery extends PartitionOperation
             default:
                 throw new RuntimeException("Unknown client type: " + settings.mode.api);
         }
+    }
+
+    private static String describeValue(Object value)
+    {
+        if (value == null) return "null";
+        if (value instanceof ByteBuffer)
+        {
+            ByteBuffer bb = (ByteBuffer) value;
+            return hexPreview(bb, 16) + " (" + bb.remaining() + " bytes)";
+        }
+        if (value instanceof byte[])
+        {
+            byte[] b = (byte[]) value;
+            return hexPreview(ByteBuffer.wrap(b), 16) + " (" + b.length + " bytes)";
+        }
+        String s = String.valueOf(value);
+        return s.length() > 80 ? s.substring(0, 80) + "..." : s;
     }
 }


### PR DESCRIPTION
## Problem

When a read validation fails, cassandra-stress emits a single generic line:

```
java.io.IOException: Operation x0 on key(s) [343632314b354e343331]: Data returned was not validated
```

This tells investigators only the key (hex-encoded). It cannot distinguish between a missing row, a truncated value, or a content corruption — three failure modes that each point to completely different root causes.

## What changed

### Key display

Blob keys are now decoded to printable ASCII when possible, showing both forms:

```
[0P37709P21 (hex: 30503337373039503231)]
```

### Row empty / missing

```
Operation x0 on key(s) [0P37709P21 (hex: 30503337373039503231)]:
  Data returned was not validated: row empty/missing
  (expected 1 row(s) with 5 column(s) [C0..C4], 1000 bytes total (5×200); got 0 rows)
```

### Value size mismatch — smaller than expected

```
Operation x0 on key(s) [0P37709P21 (hex: 30503337373039503231)]:
  Data returned was not validated: row 0, column 0 (C0):
  expected 200 bytes, got 87 bytes (value smaller than expected)
```

### Value size mismatch — larger than expected

```
Operation x0 on key(s) [0P37709P21 (hex: 30503337373039503231)]:
  Data returned was not validated: row 0, column 0 (C0):
  expected 100 bytes, got 200 bytes (value larger than expected)
```

### Same-size content mismatch (corruption)

```
Operation x0 on key(s) [0P37709P21 (hex: 30503337373039503231)]:
  Data returned was not validated: row 0, column 0 (C0):
  same size (200 bytes) but content differs;
  expected[0..15]=0xabcdef0102030405060708090a0b0c0d...,
  got[0..15]=0x1234567890abcdef0102030405060708...
```

### Row count mismatch

```
Operation x0 on key(s) [...]:
  Data returned was not validated: row count mismatch
  (expected 2 row(s) / 2000 bytes total; got 1 row(s) / 1000 bytes total)
```

### Column count mismatch

```
Operation x0 on key(s) [...]:
  Data returned was not validated: row 0 column count mismatch
  (expected 5 column(s) [C0..C4] / 1000 bytes; got 3 column(s) / 600 bytes)
```

Closes https://scylladb.atlassian.net/browse/QATOOLS-258